### PR TITLE
Fix wifi_kit_32_V3 pins

### DIFF
--- a/esp32/variants/wifi_kit_32_V3/pins_arduino.h
+++ b/esp32/variants/wifi_kit_32_V3/pins_arduino.h
@@ -15,56 +15,58 @@
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
-static const uint8_t LED_BUILTIN = 25;
+static const uint8_t LED_BUILTIN = 35;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 #define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 
-static const uint8_t TX = 1;
-static const uint8_t RX = 3;
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
 
 static const uint8_t SDA = 21;
 static const uint8_t SCL = 22;
 
-static const uint8_t SS    = 5;
-static const uint8_t MOSI  = 23;
-static const uint8_t MISO  = 19;
-static const uint8_t SCK   = 18;
+static const uint8_t SS = 8;
+static const uint8_t MOSI = 10;
+static const uint8_t MISO = 11;
+static const uint8_t SCK = 9;
 
-static const uint8_t A0 = 36;
-static const uint8_t A1 = 37;
-static const uint8_t A2 = 38;
-static const uint8_t A3 = 39;
-static const uint8_t A4 = 32;
-static const uint8_t A5 = 33;
-static const uint8_t A6 = 34;
-static const uint8_t A7 = 35;
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+static const uint8_t A7 = 8;
+static const uint8_t A8 = 9;
+static const uint8_t A9 = 10;
+static const uint8_t A10 = 11;
+static const uint8_t A11 = 12;
+static const uint8_t A12 = 13;
+static const uint8_t A13 = 14;
+static const uint8_t A14 = 15;
+static const uint8_t A15 = 16;
+static const uint8_t A16 = 17;
+static const uint8_t A17 = 18;
+static const uint8_t A18 = 19;
+static const uint8_t A19 = 20;
 
-static const uint8_t A10 = 4;
-static const uint8_t A11 = 0;
-static const uint8_t A12 = 2;
-static const uint8_t A13 = 15;
-static const uint8_t A14 = 13;
-static const uint8_t A15 = 12;
-static const uint8_t A16 = 14;
-static const uint8_t A17 = 27;
-static const uint8_t A18 = 25;
-static const uint8_t A19 = 26;
-
-static const uint8_t T0 = 4;
-static const uint8_t T1 = 0;
+static const uint8_t T1 = 1;
 static const uint8_t T2 = 2;
-static const uint8_t T3 = 15;
-static const uint8_t T4 = 13;
-static const uint8_t T5 = 12;
-static const uint8_t T6 = 14;
-static const uint8_t T7 = 27;
-static const uint8_t T8 = 33;
-static const uint8_t T9 = 32;
-
-static const uint8_t DAC1 = 25;
-static const uint8_t DAC2 = 26;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+static const uint8_t T8 = 8;
+static const uint8_t T9 = 9;
+static const uint8_t T10 = 10;
+static const uint8_t T11 = 11;
+static const uint8_t T12 = 12;
+static const uint8_t T13 = 13;
+static const uint8_t T14 = 14;
 
 static const uint8_t Vext = 36;
 static const uint8_t LED  = 35;


### PR DESCRIPTION
The pin definitions in `wifi_kit_32_V3/pins_arduino.h` appear to be copied over from `wifi_kit_32/pins_arduino.h` but were not updated to reflect the real pins on the new board.

I updated the pins by carefully reading the technical documents and schematics, and comparing to the LoRa variant in `WIFI_LoRa_32_V3`.


## Resources

WiFi V2 Board
Pinout Diagram: https://resource.heltec.cn/download/WiFi_Kit_32/WIFI_Kit_32_pinoutDiagram_V2.pdf
Schematic Diagram: https://resource.heltec.cn/download/WiFi_Kit_32/WIFI_Kit_32_Schematic_diagram_V2.1.PDF

WiFi V3 Board
Pinout Diagram: https://resource.heltec.cn/download/HTIT-WB32_V3(Rev1.1).pdf
Schematic: https://resource.heltec.cn/download/WiFi_Kit_32_V3/HTIT-WB32_V3_Schematic_Diagram.pdf

LoRa V3 Board
Pinout Diagram: https://resource.heltec.cn/download/WiFi_LoRa32_V3/HTIT-WB32LA(F)_V3.png
Schematic: https://resource.heltec.cn/download/WiFi_LoRa32_V3/HTIT-WB32LA(F)_V3_Schematic_Diagram.pdf

ESP32 Technical Reference Manual: https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf

ESP32-S3 DataSheet: https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf

Credit to @smerkadidit for noticing this and compiling resources here: https://github.com/espressif/arduino-esp32/issues/7737