### PR TITLE
backporting fix for issue #771 from LoRaMac-node

### DIFF
--- a/esp32/libraries/LoraWan102/src/radio/radio.c
+++ b/esp32/libraries/LoraWan102/src/radio/radio.c
@@ -1158,22 +1158,24 @@ void RadioIrqProcess( void )
 
         if( ( irqRegs & IRQ_RX_DONE ) == IRQ_RX_DONE )
         {
-        	//printf("rx done\r\n");
-            uint8_t size;
-            TimerStop( &RxTimeoutTimer );
-            SX126xGetPayload( RadioRxPayload, &size , 255 );
-            SX126xGetPacketStatus( &RadioPktStatus );
-            if( ( RadioEvents != NULL ) && ( RadioEvents->RxDone != NULL ) && ( irqRegs & IRQ_CRC_ERROR ) != IRQ_CRC_ERROR)
+            if( ( irqRegs & IRQ_CRC_ERROR ) == IRQ_CRC_ERROR )
             {
-                RadioEvents->RxDone( RadioRxPayload, size, RadioPktStatus.Params.LoRa.RssiPkt, RadioPktStatus.Params.LoRa.SnrPkt );
+                if( ( RadioEvents != NULL ) && ( RadioEvents->RxError ) )
+                {
+                    RadioEvents->RxError( );
+                }
             }
-        }
-
-        if( ( irqRegs & IRQ_CRC_ERROR ) == IRQ_CRC_ERROR )
-        {
-            if( ( RadioEvents != NULL ) && ( RadioEvents->RxError ) )
+            else
             {
-                RadioEvents->RxError( );
+                //printf("rx done\r\n");
+                uint8_t size;
+                TimerStop( &RxTimeoutTimer );
+                SX126xGetPayload( RadioRxPayload, &size , 255 );
+                SX126xGetPacketStatus( &RadioPktStatus );
+                if( ( RadioEvents != NULL ) && ( RadioEvents->RxDone != NULL ) && ( irqRegs & IRQ_CRC_ERROR ) != IRQ_CRC_ERROR)
+                {
+                    RadioEvents->RxDone( RadioRxPayload, size, RadioPktStatus.Params.LoRa.RssiPkt, RadioPktStatus.Params.LoRa.SnrPkt );
+                }
             }
         }
 


### PR DESCRIPTION
Hi, 

I have recently been bitten by Lora-net/LoRaMac-node#771 when radio signals are weak, resulting in wrong CRCs. 

This pull request is a simple backport of the fix that was made in the LoRaMac-node report for this issue.

Hope this can be merged quickly.

Thanks

EDIT: linking a similar pull requests in the CubeCell-arduino repo: HelTecAutomation/CubeCell-Arduino#267.