### PR TITLE
Add missing macro values to V3 boards

### DIFF
--- a/esp32/boards.txt
+++ b/esp32/boards.txt
@@ -631,11 +631,11 @@ wifi_lora_32.build.variant=wifi_lora_32
 wifi_lora_32.build.board=WIFI_LoRa_32
 
 wifi_lora_32.build.f_cpu=240000000L
-wifi_lora_32.build.flash_size=8MB
+wifi_lora_32.build.flash_size=4MB
 wifi_lora_32.build.flash_freq=80m
 wifi_lora_32.build.flash_mode=dio
 wifi_lora_32.build.boot=dio
-wifi_lora_32.build.partitions=default_8MB
+wifi_lora_32.build.partitions=default
 wifi_lora_32.build.defines=-D{build.band} -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
 wifi_lora_32.build.extra_libs=-lheltec
 

--- a/esp32/variants/WIFI_LoRa_32_V3/pins_arduino.h
+++ b/esp32/variants/WIFI_LoRa_32_V3/pins_arduino.h
@@ -4,6 +4,10 @@
 #include <stdint.h>
 #include "soc/soc_caps.h"
 
+#define WIFI_LoRa_32_V3 true
+#define DISPLAY_HEIGHT 64
+#define DISPLAY_WIDTH  128
+
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
@@ -76,4 +80,9 @@ static const uint8_t LED  = 35;
 static const uint8_t RST_OLED = 21;
 static const uint8_t SCL_OLED = 18;
 static const uint8_t SDA_OLED = 17;
+
+static const uint8_t RST_LoRa = 12;
+static const uint8_t BUSY_LoRa = 13;
+static const uint8_t DIO0 = 14;
+
 #endif /* Pins_Arduino_h */

--- a/esp32/variants/Wireless_Stick_V3/pins_arduino.h
+++ b/esp32/variants/Wireless_Stick_V3/pins_arduino.h
@@ -4,6 +4,10 @@
 #include <stdint.h>
 #include "soc/soc_caps.h"
 
+#define Wireless_Stick_V3 true
+#define DISPLAY_HEIGHT 32
+#define DISPLAY_WIDTH  64
+
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 

--- a/esp32/variants/wifi_kit_32_V3/pins_arduino.h
+++ b/esp32/variants/wifi_kit_32_V3/pins_arduino.h
@@ -3,17 +3,17 @@
 
 #include <stdint.h>
 
-#define WIFI_Kit_32	true
+#define WIFI_Kit_32_V3	true
 #define DISPLAY_HEIGHT 64
 #define DISPLAY_WIDTH  128
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
+#define EXTERNAL_NUM_INTERRUPTS 46
+#define NUM_DIGITAL_PINS        48
+#define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
+#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t LED_BUILTIN = 35;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
@@ -73,5 +73,7 @@ static const uint8_t LED  = 35;
 static const uint8_t RST_OLED = 21;
 static const uint8_t SCL_OLED = 18;
 static const uint8_t SDA_OLED = 17;
+
+static const uint8_t DIO0 = 14;
 
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
Without macros defined like `DISPLAY_HEIGHT`, `DISPLAY_WIDTH` and `DIO0`, features on the V3 boards won't compile properly.

This PR corrects the definitions for: `WIFI_LoRa_32_V3`, `Wireless_Stick_V3`, and `WIFI_Kit_32_V3`

This should help fix #156 fix #164 and help with #157 and #161

Thanks!
