### PR TITLE
Remove esp8266/LittleFS from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "esp8266/libraries/ESP8266SdFat"]
 	path = esp8266/libraries/ESP8266SdFat
 	url = https://github.com/earlephilhower/ESP8266SdFat.git
-[submodule "esp8266/libraries/LittleFS/lib/littlefs"]
-	path = esp8266/libraries/LittleFS/lib/littlefs
-	url = https://github.com/esp8266/Arduino/libraries/LittleFS.git
 [submodule "esp8266/libraries/SoftwareSerial"]
 	path = esp8266/libraries/SoftwareSerial
 	url = https://github.com/PaulStoffregen/SoftwareSerial.git


### PR DESCRIPTION
remove dependency on no-longer-existent esp8266/LittleFS, allowing the git clone --recursive to complete successfully