### PR TITLE
Don't crash if queue not inited

### DIFF
--- a/esp32/libraries/LoraWan102/src/loramac/LoRaMacConfirmQueue.c
+++ b/esp32/libraries/LoraWan102/src/loramac/LoRaMacConfirmQueue.c
@@ -124,7 +124,7 @@ void LoRaMacConfirmQueueInit( LoRaMacPrimitives_t* primitives )
 
 bool LoRaMacConfirmQueueAdd( MlmeConfirmQueue_t* mlmeConfirm )
 {
-    if( MlmeConfirmQueueCnt >= LORA_MAC_MLME_CONFIRM_QUEUE_LEN )
+    if( MlmeConfirmQueueCnt >= LORA_MAC_MLME_CONFIRM_QUEUE_LEN || !BufferEnd )
     {
         // Protect the buffer against overwrites
         return false;


### PR DESCRIPTION
An initial spi timeout after boot will eventually add a confirm to the queue that has not been initialized, causing a panic and reboot. While this situation may not occur often, it is surfacing during debugging.