### PR TITLE
compile time linux error: pins_arduino.h 'no such file': boards<=> fi…

### DIFF
--- a/esp32/boards.txt
+++ b/esp32/boards.txt
@@ -532,7 +532,7 @@ wifi_kit_32_V3.build.bootloader_addr=0x0
 wifi_kit_32_V3.build.target=esp32s3
 wifi_kit_32_V3.build.mcu=esp32s3
 wifi_kit_32_V3.build.core=esp32
-wifi_kit_32_V3.build.variant=wifi_kit_32_V3
+wifi_kit_32_V3.build.variant=wifi_kit_32_v3    // upper case change to lower, to prevent Linux complie error: pins_arduino.h 'no such file'
 wifi_kit_32_V3.build.board=wifi_kit_32_V3
 
 wifi_kit_32_V3.build.usb_mode=1


### PR DESCRIPTION
…lename mismatch

Line 535: change of case from upper to lower (V3 => v3) to prevent linux compile error : pins_arduino.h 'no such file'. Case will then match filename.  I'm not sure this is the right place lodge this pull request, as the arduino files are in the form heltec_wifi_kit_32_V3.   Sorry if I have this wrong, total newbie with github. Also, not sure if I should have put the comment on line 535. 