### PR TITLE
wifi_kit_32_V3: fix I2C pins for the user available channel

### DIFF
--- a/variants/heltec_wifi_kit_32_V3/pins_arduino.h
+++ b/variants/heltec_wifi_kit_32_V3/pins_arduino.h
@@ -16,8 +16,8 @@ static const uint8_t KEY_BUILTIN = 0;
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
 
-static const uint8_t SDA = 21;
-static const uint8_t SCL = 22;
+static const uint8_t SDA = 41;
+static const uint8_t SCL = 42;
 
 static const uint8_t SS = 8;
 static const uint8_t MOSI = 10;


### PR DESCRIPTION
see issue: https://stackoverflow.com/questions/75626663/how-to-connect-two-i2c-sensors-to-the-heltec-wifi-kit-v3-esp32-board