### PR TITLE
Update boards.txt

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -2774,8 +2774,8 @@ heltec_wifi_lora_32_V4.menu.USBMode.hwcdc.build.usb_mode=1
 heltec_wifi_lora_32_V4.menu.USBMode.default=USB-OTG (TinyUSB)
 heltec_wifi_lora_32_V4.menu.USBMode.default.build.usb_mode=0
 
-heltec_wifi_lora_32_V4.menu.CDCOnBoot.default=Disabled
-heltec_wifi_lora_32_V4.menu.CDCOnBoot.default.build.cdc_on_boot=0
+heltec_wifi_lora_32_V4.menu.CDCOnBoot.default=Enabled
+heltec_wifi_lora_32_V4.menu.CDCOnBoot.default.build.cdc_on_boot=1
 heltec_wifi_lora_32_V4.menu.CDCOnBoot.cdc=Enabled
 heltec_wifi_lora_32_V4.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
 


### PR DESCRIPTION
The Tools menu settings for the WiFi LoRa 32 V4 board menu.CDCOnBoot.default [Enabled] and menu.CDCOnBoot.default [1] should reflect the requirement for USB CDC On Boot to be enabled to provide Serial Monitor output.